### PR TITLE
Add DataLad usage documentation and container image labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ If you plan on using this cache regularly, clone the `dist` branch of this repos
 git clone --branch dist https://github.com/dandi-cache/content-id-to-dandiset-paths.git
 ```
 
-Or, if you prefer [DataLad](https://www.datalad.org/) (options after the URL are passed through to `git clone`):
+Or, if you prefer [DataLad](https://www.datalad.org/):
 
 ```bash
-datalad clone https://github.com/dandi-cache/content-id-to-dandiset-paths.git --branch dist
+datalad clone https://github.com/dandi-cache/content-id-to-dandiset-paths.git --branch derivatives
 ```
 
 Then set up a CRON on your system to pull the latest version of the cache at your desired frequency.
@@ -66,12 +66,6 @@ For example, through `crontab -e`, add:
 
 ```bash
 0 0 * * * git -C /path/to/content-id-to-dandiset-paths pull
-```
-
-Or, with DataLad:
-
-```bash
-0 0 * * * datalad update -d /path/to/content-id-to-dandiset-paths --how merge
 ```
 
 This will minimize data overhead by only loading the most recent changes.

--- a/README.md
+++ b/README.md
@@ -54,12 +54,24 @@ If you plan on using this cache regularly, clone the `dist` branch of this repos
 git clone --branch dist https://github.com/dandi-cache/content-id-to-dandiset-paths.git
 ```
 
+Or, if you prefer [DataLad](https://www.datalad.org/) (options after the URL are passed through to `git clone`):
+
+```bash
+datalad clone https://github.com/dandi-cache/content-id-to-dandiset-paths.git --branch dist
+```
+
 Then set up a CRON on your system to pull the latest version of the cache at your desired frequency.
 
 For example, through `crontab -e`, add:
 
 ```bash
 0 0 * * * git -C /path/to/content-id-to-dandiset-paths pull
+```
+
+Or, with DataLad:
+
+```bash
+0 0 * * * datalad update -d /path/to/content-id-to-dandiset-paths --how merge
 ```
 
 This will minimize data overhead by only loading the most recent changes.

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -12,6 +12,10 @@
 # it provides Python and a recent git-annex-standalone, which DataLad requires for the annex-backed dataset and its provenance.
 FROM neurodebian:trixie
 
+# The source label associates the image on the GitHub Container Registry with this repository.
+LABEL org.opencontainers.image.source="https://github.com/dandi-cache/content-id-to-dandiset-paths"
+LABEL org.opencontainers.image.description="The pinned runtime environment for the DANDI Cache content-id-to-dandiset-paths update pipeline."
+
 # git-annex (for DataLad / annex provenance), Python, and the basics for cloning and TLS.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
This PR enhances the repository documentation and container configuration with improved setup and maintenance instructions.

**Key changes made:**

- **README.md**: Added DataLad as an alternative method for cloning the cache repository, including:
  - Instructions for cloning using `datalad clone` command
  - CRON job example using `datalad update` for automated cache updates
  
- **Dockerfile**: Added OCI image labels to associate the container image with the GitHub repository:
  - `org.opencontainers.image.source`: Links the image to the GitHub repository
  - `org.opencontainers.image.description`: Describes the image purpose

**Implementation details:**

The DataLad instructions follow the same pattern as the existing git clone approach, making it easy for users familiar with DataLad to use it as an alternative. The CRON example uses `datalad update` with the `--how merge` strategy to keep the dataset synchronized with minimal overhead.

The Dockerfile labels follow the OpenContainers Image Spec standard, enabling better discoverability and linking of the container image on registries like GitHub Container Registry.

https://claude.ai/code/session_014ZPzHUEAxmo4GiP1KjQ6HN