### PR TITLE
Clarify workflow limit parameter for dev-testing only

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -10,10 +10,12 @@ on:
   workflow_dispatch:
     inputs:
       limit:
-        description: "Optional cap on the number of new items to process in this run. Clear the field for a complete run."
+        # The pipeline is not incremental: every run regenerates the full cache from scratch, so a
+        # limited run produces a truncated output, not a partial addition. Only set this to
+        # dev-test changes; leave empty for a real update.
+        description: "Dev-testing only: cap the run at this many asset entries (produces a truncated output). Leave empty for a complete update."
         required: false
         type: number
-        default: 10
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -65,9 +67,9 @@ jobs:
         env:
           REPO_URL: https://x-access-token:${{ secrets._GITHUB_API_KEY }}@github.com/${{ github.repository }}.git
           WORKSPACE: ${{ github.workspace }}
-          # Scheduled runs must process the full archive: an empty LIMIT means no cap.
-          # Only manual (workflow_dispatch) runs pass a limit, as a testing knob.
-          LIMIT: ${{ github.event.inputs.limit || '' }}
+          # Empty for scheduled and plain manual runs (complete update); only set when a
+          # dev-test limit is explicitly entered on workflow_dispatch.
+          LIMIT: ${{ github.event.inputs.limit }}
           GITHUB_SHA: ${{ github.sha }}
           IMAGE: ghcr.io/dandi-cache/content-id-to-dandiset-paths:latest
         run: bash code/update_pipeline.sh

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       limit:
-        description: "Optional cap on the number of new items to process in this run."
+        description: "Optional cap on the number of new items to process in this run. Clear the field for a complete run."
         required: false
         type: number
         default: 10
@@ -65,7 +65,9 @@ jobs:
         env:
           REPO_URL: https://x-access-token:${{ secrets._GITHUB_API_KEY }}@github.com/${{ github.repository }}.git
           WORKSPACE: ${{ github.workspace }}
-          LIMIT: ${{ github.event.inputs.limit || '2000' }}
+          # Scheduled runs must process the full archive: an empty LIMIT means no cap.
+          # Only manual (workflow_dispatch) runs pass a limit, as a testing knob.
+          LIMIT: ${{ github.event.inputs.limit || '' }}
           GITHUB_SHA: ${{ github.sha }}
           IMAGE: ghcr.io/dandi-cache/content-id-to-dandiset-paths:latest
         run: bash code/update_pipeline.sh


### PR DESCRIPTION
## Summary
Updated the GitHub Actions workflow documentation and behavior to clarify that the `limit` parameter is intended for dev-testing purposes only, not for partial production updates.

## Key Changes
- **Updated parameter description**: Clarified that the limit produces truncated output (not incremental additions) and should only be used for dev-testing
- **Removed default value**: Deleted the `default: 10` to ensure the parameter is truly optional and empty for production runs
- **Fixed LIMIT environment variable**: Changed from `github.event.inputs.limit || '2000'` to just `github.event.inputs.limit` so it's empty for scheduled/manual runs without explicit input, allowing the pipeline script to handle the default behavior
- **Added inline comments**: Documented the pipeline's non-incremental nature and clarified when the limit should be set

## Implementation Details
The pipeline regenerates the full cache from scratch on every run, so applying a limit doesn't produce a partial addition to existing data—it produces a truncated complete output. This change ensures users understand this behavior and only use the limit parameter when intentionally testing with reduced data, not when performing actual production updates.

https://claude.ai/code/session_014cEYHy6iGJrkCAZ6TjCUxW