### PR TITLE
Make the cache accumulative by merging in its previous state on each update

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -10,12 +10,10 @@ on:
   workflow_dispatch:
     inputs:
       limit:
-        # The pipeline is not incremental: every run regenerates the full cache from scratch, so a
-        # limited run produces a truncated output, not a partial addition. A limited run also
-        # skips change tracking and marks the snapshot as truncated (`derivatives/.truncated`),
-        # so the next full run re-baselines `changes.jsonl` instead of logging spurious diffs.
-        # Only set this to dev-test changes; leave empty for a real update.
-        description: "Dev-testing only: cap the run at this many asset entries (produces a truncated output). Leave empty for a complete update."
+        # The cache is accumulative: every run merges the fresh S3 state into the previous cache,
+        # so a limited run only refreshes the first N asset entries -- existing entries are
+        # retained either way. Only set this to dev-test changes; leave empty for a real update.
+        description: "Dev-testing only: cap the run at this many fresh asset entries (existing cache entries are retained). Leave empty for a complete update."
         required: false
         type: number
 

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -11,8 +11,10 @@ on:
     inputs:
       limit:
         # The pipeline is not incremental: every run regenerates the full cache from scratch, so a
-        # limited run produces a truncated output, not a partial addition. Only set this to
-        # dev-test changes; leave empty for a real update.
+        # limited run produces a truncated output, not a partial addition. A limited run also
+        # skips change tracking and marks the snapshot as truncated (`derivatives/.truncated`),
+        # so the next full run re-baselines `changes.jsonl` instead of logging spurious diffs.
+        # Only set this to dev-test changes; leave empty for a real update.
         description: "Dev-testing only: cap the run at this many asset entries (produces a truncated output). Leave empty for a complete update."
         required: false
         type: number

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -9,13 +9,13 @@ on:
     - cron: "0 0/2 * * *"  # Every two hours.
   workflow_dispatch:
     inputs:
-      limit:
-        # The cache is accumulative: every run merges the fresh S3 state into the previous cache,
-        # so a limited run only refreshes the first N asset entries -- existing entries are
-        # retained either way. Only set this to dev-test changes; leave empty for a real update.
-        description: "Dev-testing only: cap the run at this many fresh asset entries (existing cache entries are retained). Leave empty for a complete update."
+      testing:
+        # A testing run processes only ten asset entries and reads/writes
+        # derivatives/testing.jsonl, so the real cache is never touched.
+        description: "Testing mode: process only ten asset entries and write to derivatives/testing.jsonl instead of the real cache."
         required: false
-        type: number
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -67,9 +67,9 @@ jobs:
         env:
           REPO_URL: https://x-access-token:${{ secrets._GITHUB_API_KEY }}@github.com/${{ github.repository }}.git
           WORKSPACE: ${{ github.workspace }}
-          # Empty for scheduled and plain manual runs (complete update); only set when a
-          # dev-test limit is explicitly entered on workflow_dispatch.
-          LIMIT: ${{ github.event.inputs.limit }}
+          # Empty for scheduled runs and "false" for plain manual runs (complete update);
+          # only "true" when testing mode is explicitly selected on workflow_dispatch.
+          TESTING: ${{ github.event.inputs.testing }}
           GITHUB_SHA: ${{ github.sha }}
           IMAGE: ghcr.io/dandi-cache/content-id-to-dandiset-paths:latest
         run: bash code/update_pipeline.sh

--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ Each line is one JSON record mapping a content ID to the Dandisets and paths it 
 {"<content_id>": {"<dandiset_id>": ["<path/in/dandiset>", "..."]}}
 ```
 
+## Change history
+
+Each update also diffs the fresh snapshot against the previous one and appends the deltas to an accumulating change log, `derivatives/changes.jsonl` (also available compressed on the `dist` branch as `derivatives/changes.jsonl.gz`), so changes to the mapping are tracked explicitly for as long as the cache lives.
+
+Each line is one JSON record describing one content ID whose mapping changed during one update:
+
+```json
+{"timestamp": "<UTC ISO 8601 time of the update>", "content_id": "<content_id>", "change": "added|removed|changed", "previous": {"<dandiset_id>": ["<path/in/dandiset>", "..."]}, "current": {"<dandiset_id>": ["<path/in/dandiset>", "..."]}}
+```
+
+`previous` is `null` for `added` records and `current` is `null` for `removed` records. All records from the same update share the same timestamp. The log begins at the first update after the cache was bootstrapped; the full commit-level history of every snapshot is additionally retained on the `derivatives` branch.
+
 ### Save to file
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # DANDI Cache: `content-id-to-dandiset-paths`
 
-Maps content ID relationship to current Dandiset paths.
+Maps content ID relationship to Dandiset paths, accumulated over time.
 
-For each content ID (the identifier embedded in a blob's S3 download URL), this cache records every Dandiset and the path(s) within that Dandiset where an asset with that content currently lives.
+For each content ID (the identifier embedded in a blob's S3 download URL), this cache records every Dandiset and the path(s) within that Dandiset where an asset with that content has been seen.
+
+The cache is accumulative: each update merges the current state of the DANDI archive into the previous state of the cache, so new Dandisets and paths are added when first seen and existing entries are retained even if they later disappear upstream — the cache tracks everywhere content has ever lived for as long as the cache exists.
 
 Updated frequently.
 
@@ -32,23 +34,11 @@ content_id_to_dandiset_paths = {
 }
 ```
 
-Each line is one JSON record mapping a content ID to the Dandisets and paths it appears at:
+Each line is one JSON record mapping a content ID to the Dandisets and paths it has been seen at:
 
 ```json
 {"<content_id>": {"<dandiset_id>": ["<path/in/dandiset>", "..."]}}
 ```
-
-## Change history
-
-Each update also diffs the fresh snapshot against the previous one and appends the deltas to an accumulating change log, `derivatives/changes.jsonl` (also available compressed on the `dist` branch as `derivatives/changes.jsonl.gz`), so changes to the mapping are tracked explicitly for as long as the cache lives.
-
-Each line is one JSON record describing one content ID whose mapping changed during one update:
-
-```json
-{"timestamp": "<UTC ISO 8601 time of the update>", "content_id": "<content_id>", "change": "added|removed|changed", "previous": {"<dandiset_id>": ["<path/in/dandiset>", "..."]}, "current": {"<dandiset_id>": ["<path/in/dandiset>", "..."]}}
-```
-
-`previous` is `null` for `added` records and `current` is `null` for `removed` records. All records from the same update share the same timestamp. The log begins at the first update after the cache was bootstrapped; the full commit-level history of every snapshot is additionally retained on the `derivatives` branch.
 
 ### Save to file
 

--- a/code/update.py
+++ b/code/update.py
@@ -1,7 +1,6 @@
 import argparse
 import collections
 import concurrent.futures
-import datetime
 import json
 import pathlib
 
@@ -79,57 +78,17 @@ def _collect_records(
     return records
 
 
-def _load_previous_snapshot(snapshot_file_path: pathlib.Path) -> dict[str, dict[str, list[str]]] | None:
-    """Read the previous run's snapshot back into memory, or return None on a bootstrap run."""
-    if not snapshot_file_path.exists():
+def _load_previous_cache(cache_file_path: pathlib.Path) -> dict[str, dict[str, list[str]]] | None:
+    """Read the previous run's cache back into memory, or return None on a bootstrap run."""
+    if not cache_file_path.exists():
         return None
 
-    previous_snapshot: dict[str, dict[str, list[str]]] = {}
-    with snapshot_file_path.open() as file_stream:
+    previous_cache: dict[str, dict[str, list[str]]] = {}
+    with cache_file_path.open() as file_stream:
         for line in file_stream:
             if stripped_line := line.strip():
-                previous_snapshot.update(json.loads(stripped_line))
-    return previous_snapshot
-
-
-def _append_changes(
-    changes_file_path: pathlib.Path,
-    previous_snapshot: dict[str, dict[str, list[str]]],
-    current_snapshot: dict[str, dict[str, list[str]]],
-) -> int:
-    """Append one change record per content ID whose mapping differs from the previous run.
-
-    Each record is one JSON value per line:
-    `{"timestamp": ..., "content_id": ..., "change": "added"|"removed"|"changed", "previous": ..., "current": ...}`
-    where `previous`/`current` hold the full `{"<dandiset_id>": ["<path>", ...]}` mapping
-    (null on the side where the content ID does not exist). All records from one run share
-    the same timestamp. Returns the number of records appended.
-    """
-    timestamp = datetime.datetime.now(tz=datetime.timezone.utc).isoformat(timespec="seconds")
-
-    change_records = []
-    for content_id in sorted(previous_snapshot.keys() | current_snapshot.keys()):
-        previous = previous_snapshot.get(content_id)
-        current = current_snapshot.get(content_id)
-        if previous == current:
-            continue
-
-        change = "added" if previous is None else "removed" if current is None else "changed"
-        change_records.append(
-            {
-                "timestamp": timestamp,
-                "content_id": content_id,
-                "change": change,
-                "previous": previous,
-                "current": current,
-            }
-        )
-
-    if len(change_records) > 0:
-        with changes_file_path.open(mode="a") as file_stream:
-            for change_record in change_records:
-                file_stream.write(f"{json.dumps(change_record)}\n")
-    return len(change_records)
+                previous_cache.update(json.loads(stripped_line))
+    return previous_cache
 
 
 def _run(base_directory: pathlib.Path, max_workers: int, limit: int | None) -> None:
@@ -146,58 +105,32 @@ def _run(base_directory: pathlib.Path, max_workers: int, limit: int | None) -> N
     content_id_to_dandiset_paths: dict[str, dict[str, set[str]]] = collections.defaultdict(
         lambda: collections.defaultdict(set)
     )
-    for content_id, dandiset_id, path_in_dandiset in records:
-        content_id_to_dandiset_paths[content_id][dandiset_id].add(path_in_dandiset)
-
-    # Normalize into the exact structure written to (and read back from) the snapshot file, so
-    # diffing against the previous run is a plain per-content-ID equality check.
-    current_snapshot = {
-        content_id: {
-            dandiset_id: sorted(content_id_to_dandiset_paths[content_id][dandiset_id])
-            for dandiset_id in sorted(content_id_to_dandiset_paths[content_id])
-        }
-        for content_id in sorted(content_id_to_dandiset_paths)
-    }
 
     derivatives_directory = base_directory / "derivatives"
     derivatives_directory.mkdir(parents=True, exist_ok=True)
-    snapshot_file_path = derivatives_directory / "content_id_to_dandiset_paths.jsonl"
+    output_file_path = derivatives_directory / "content_id_to_dandiset_paths.jsonl"
 
-    # The pipeline runs on a clone of the persistent `derivatives` branch, so the previous run's
-    # snapshot is already present here. Diff against it before overwriting, appending the deltas
-    # to `changes.jsonl` so the cache carries an explicit change history for as long as it lives.
-    # Skipped on a bootstrap run (the initial snapshot itself is the baseline), on limited
-    # (testing) runs (their truncated snapshot would only log noise), and on the first full run
-    # after a limited run (diffing against the truncated snapshot would log every entry it
-    # dropped as a spurious change) -- the `.truncated` marker carries that last state between
-    # runs on the `derivatives` branch.
-    truncated_marker_file_path = derivatives_directory / ".truncated"
-    if limit is not None:
-        truncated_marker_file_path.write_text(
-            "The snapshot was last written by a limited (testing) run and is truncated.\n"
-            "The next full run re-baselines change tracking instead of diffing against it.\n"
-        )
-    elif truncated_marker_file_path.exists():
-        print("The previous snapshot was truncated by a limited run; re-baselining change tracking.")
-        truncated_marker_file_path.unlink()
-    else:
-        previous_snapshot = _load_previous_snapshot(snapshot_file_path)
-        if previous_snapshot is not None:
-            changes_file_path = derivatives_directory / "changes.jsonl"
-            number_of_changes = _append_changes(
-                changes_file_path=changes_file_path,
-                previous_snapshot=previous_snapshot,
-                current_snapshot=current_snapshot,
-            )
-            if number_of_changes > 0:
-                print(f"Appended {number_of_changes} change record(s) to {changes_file_path}.")
-            else:
-                print("No changes since the previous snapshot.")
+    # The cache is accumulative: the pipeline runs on a clone of the persistent `derivatives`
+    # branch, so the previous run's cache is already present here. Seed the mapping with it before
+    # folding in the fresh S3 state, so new Dandiset IDs and paths are added when first seen and
+    # entries that have since disappeared upstream are retained for as long as the cache lives.
+    previous_cache = _load_previous_cache(output_file_path)
+    if previous_cache is not None:
+        for content_id, dandiset_paths in previous_cache.items():
+            for dandiset_id, paths_in_dandiset in dandiset_paths.items():
+                content_id_to_dandiset_paths[content_id][dandiset_id].update(paths_in_dandiset)
+
+    for content_id, dandiset_id, path_in_dandiset in records:
+        content_id_to_dandiset_paths[content_id][dandiset_id].add(path_in_dandiset)
 
     # One JSON value per line: `{"<content_id>": {"<dandiset_id>": ["<path>", ...]}}`.
-    with snapshot_file_path.open(mode="w") as file_stream:
-        for content_id, dandiset_paths in current_snapshot.items():
-            file_stream.write(f"{json.dumps({content_id: dandiset_paths})}\n")
+    with output_file_path.open(mode="w") as file_stream:
+        for content_id in sorted(content_id_to_dandiset_paths):
+            dandiset_paths = content_id_to_dandiset_paths[content_id]
+            record = {
+                content_id: {dandiset_id: sorted(dandiset_paths[dandiset_id]) for dandiset_id in sorted(dandiset_paths)}
+            }
+            file_stream.write(f"{json.dumps(record)}\n")
 
 
 if __name__ == "__main__":
@@ -225,9 +158,9 @@ if __name__ == "__main__":
         type=int,
         default=None,
         help=(
-            "Optional cap on the number of asset entries to process (the output has at most "
-            "this many records). Primarily a testing knob for fast, partial runs; omit for a "
-            "complete cache."
+            "Optional cap on the number of fresh asset entries to process from S3. The results "
+            "still merge into the previous cache, so existing entries are retained. Primarily a "
+            "testing knob for fast, partial runs; omit for a complete update."
         ),
     )
     args = parser.parse_args()

--- a/code/update.py
+++ b/code/update.py
@@ -84,12 +84,12 @@ def _collect_records(
     return records
 
 
-def _load_previous_cache(cache_file_path: pathlib.Path) -> dict[str, dict[str, list[str]]] | None:
-    """Read the previous run's cache back into memory, or return None on a bootstrap run."""
-    if not cache_file_path.exists():
-        return None
-
+def _load_previous_cache(cache_file_path: pathlib.Path) -> dict[str, dict[str, list[str]]]:
+    """Read the previous run's cache back into memory (empty on a bootstrap run)."""
     previous_cache: dict[str, dict[str, list[str]]] = {}
+    if not cache_file_path.exists():
+        return previous_cache
+
     with cache_file_path.open() as file_stream:
         for line in file_stream:
             if stripped_line := line.strip():
@@ -123,10 +123,9 @@ def _run(base_directory: pathlib.Path, max_workers: int, testing: bool) -> None:
     # folding in the fresh S3 state, so new Dandiset IDs and paths are added when first seen and
     # entries that have since disappeared upstream are retained for as long as the cache lives.
     previous_cache = _load_previous_cache(output_file_path)
-    if previous_cache is not None:
-        for content_id, dandiset_paths in previous_cache.items():
-            for dandiset_id, paths_in_dandiset in dandiset_paths.items():
-                content_id_to_dandiset_paths[content_id][dandiset_id].update(paths_in_dandiset)
+    for content_id, dandiset_paths in previous_cache.items():
+        for dandiset_id, paths_in_dandiset in dandiset_paths.items():
+            content_id_to_dandiset_paths[content_id][dandiset_id].update(paths_in_dandiset)
 
     for content_id, dandiset_id, path_in_dandiset in records:
         content_id_to_dandiset_paths[content_id][dandiset_id].add(path_in_dandiset)

--- a/code/update.py
+++ b/code/update.py
@@ -19,6 +19,12 @@ _REGION = "us-east-2"
 _ASSETS_PREFIX = "dandisets/"
 _ASSETS_SUFFIX = "/assets.yaml"
 
+# Testing mode processes only this many asset entries and writes to its own designated file
+# (`derivatives/testing.jsonl`), leaving the real cache untouched.
+_TESTING_LIMIT = 10
+_CACHE_FILE_NAME = "content_id_to_dandiset_paths.jsonl"
+_TESTING_FILE_NAME = "testing.jsonl"
+
 
 def _build_s3_client() -> "botocore.client.BaseClient":
     # `dandiarchive` is a public bucket, so requests are sent unsigned (anonymous).
@@ -56,18 +62,18 @@ def _get_info(s3_client: "botocore.client.BaseClient", key: str) -> list[tuple[s
 
 
 def _collect_records(
-    s3_client: "botocore.client.BaseClient", max_workers: int, limit: int | None
+    s3_client: "botocore.client.BaseClient", max_workers: int, testing: bool
 ) -> list[tuple[str, str, str]]:
-    if limit is not None:
-        # Limited (testing) run: stream manifests one at a time and stop as soon as `limit`
-        # asset entries have been collected, so a small `--limit` yields a correspondingly
-        # small, fast output and does not enumerate the entire `dandisets/` prefix.
+    if testing:
+        # Testing run: stream manifests one at a time and stop as soon as `_TESTING_LIMIT`
+        # asset entries have been collected, so the run is fast and does not enumerate the
+        # entire `dandisets/` prefix.
         records: list[tuple[str, str, str]] = []
         for key in _iter_asset_manifest_keys(s3_client):
             records.extend(_get_info(s3_client, key))
-            if len(records) >= limit:
+            if len(records) >= _TESTING_LIMIT:
                 break
-        return records[:limit]
+        return records[:_TESTING_LIMIT]
 
     # Full run: fetch every manifest concurrently and aggregate all asset entries.
     keys = sorted(_iter_asset_manifest_keys(s3_client))
@@ -91,10 +97,10 @@ def _load_previous_cache(cache_file_path: pathlib.Path) -> dict[str, dict[str, l
     return previous_cache
 
 
-def _run(base_directory: pathlib.Path, max_workers: int, limit: int | None) -> None:
+def _run(base_directory: pathlib.Path, max_workers: int, testing: bool) -> None:
     s3_client = _build_s3_client()
 
-    records = _collect_records(s3_client, max_workers=max_workers, limit=limit)
+    records = _collect_records(s3_client, max_workers=max_workers, testing=testing)
     if len(records) == 0:
         message = (
             f"\nNo asset entries found under `s3://{_BUCKET}/{_ASSETS_PREFIX}`.\n"
@@ -108,7 +114,9 @@ def _run(base_directory: pathlib.Path, max_workers: int, limit: int | None) -> N
 
     derivatives_directory = base_directory / "derivatives"
     derivatives_directory.mkdir(parents=True, exist_ok=True)
-    output_file_path = derivatives_directory / "content_id_to_dandiset_paths.jsonl"
+    # Testing runs read from and write to their own designated file, so the real cache is
+    # never touched.
+    output_file_path = derivatives_directory / (_TESTING_FILE_NAME if testing else _CACHE_FILE_NAME)
 
     # The cache is accumulative: the pipeline runs on a clone of the persistent `derivatives`
     # branch, so the previous run's cache is already present here. Seed the mapping with it before
@@ -154,15 +162,14 @@ if __name__ == "__main__":
         help="Number of concurrent S3 download workers used to fetch the asset manifests.",
     )
     parser.add_argument(
-        "--limit",
-        type=int,
-        default=None,
+        "--testing",
+        action="store_true",
         help=(
-            "Optional cap on the number of fresh asset entries to process from S3. The results "
-            "still merge into the previous cache, so existing entries are retained. Primarily a "
-            "testing knob for fast, partial runs; omit for a complete update."
+            f"Run in testing mode: process only the first {_TESTING_LIMIT} asset entries from S3 "
+            f"and read/write `derivatives/{_TESTING_FILE_NAME}` instead of the real cache, "
+            "leaving it untouched. Omit for a complete update."
         ),
     )
     args = parser.parse_args()
 
-    _run(base_directory=args.base_directory, max_workers=args.max_workers, limit=args.limit)
+    _run(base_directory=args.base_directory, max_workers=args.max_workers, testing=args.testing)

--- a/code/update.py
+++ b/code/update.py
@@ -1,6 +1,7 @@
 import argparse
 import collections
 import concurrent.futures
+import datetime
 import json
 import pathlib
 
@@ -78,6 +79,59 @@ def _collect_records(
     return records
 
 
+def _load_previous_snapshot(snapshot_file_path: pathlib.Path) -> dict[str, dict[str, list[str]]] | None:
+    """Read the previous run's snapshot back into memory, or return None on a bootstrap run."""
+    if not snapshot_file_path.exists():
+        return None
+
+    previous_snapshot: dict[str, dict[str, list[str]]] = {}
+    with snapshot_file_path.open() as file_stream:
+        for line in file_stream:
+            if stripped_line := line.strip():
+                previous_snapshot.update(json.loads(stripped_line))
+    return previous_snapshot
+
+
+def _append_changes(
+    changes_file_path: pathlib.Path,
+    previous_snapshot: dict[str, dict[str, list[str]]],
+    current_snapshot: dict[str, dict[str, list[str]]],
+) -> int:
+    """Append one change record per content ID whose mapping differs from the previous run.
+
+    Each record is one JSON value per line:
+    `{"timestamp": ..., "content_id": ..., "change": "added"|"removed"|"changed", "previous": ..., "current": ...}`
+    where `previous`/`current` hold the full `{"<dandiset_id>": ["<path>", ...]}` mapping
+    (null on the side where the content ID does not exist). All records from one run share
+    the same timestamp. Returns the number of records appended.
+    """
+    timestamp = datetime.datetime.now(tz=datetime.timezone.utc).isoformat(timespec="seconds")
+
+    change_records = []
+    for content_id in sorted(previous_snapshot.keys() | current_snapshot.keys()):
+        previous = previous_snapshot.get(content_id)
+        current = current_snapshot.get(content_id)
+        if previous == current:
+            continue
+
+        change = "added" if previous is None else "removed" if current is None else "changed"
+        change_records.append(
+            {
+                "timestamp": timestamp,
+                "content_id": content_id,
+                "change": change,
+                "previous": previous,
+                "current": current,
+            }
+        )
+
+    if len(change_records) > 0:
+        with changes_file_path.open(mode="a") as file_stream:
+            for change_record in change_records:
+                file_stream.write(f"{json.dumps(change_record)}\n")
+    return len(change_records)
+
+
 def _run(base_directory: pathlib.Path, max_workers: int, limit: int | None) -> None:
     s3_client = _build_s3_client()
 
@@ -95,18 +149,55 @@ def _run(base_directory: pathlib.Path, max_workers: int, limit: int | None) -> N
     for content_id, dandiset_id, path_in_dandiset in records:
         content_id_to_dandiset_paths[content_id][dandiset_id].add(path_in_dandiset)
 
+    # Normalize into the exact structure written to (and read back from) the snapshot file, so
+    # diffing against the previous run is a plain per-content-ID equality check.
+    current_snapshot = {
+        content_id: {
+            dandiset_id: sorted(content_id_to_dandiset_paths[content_id][dandiset_id])
+            for dandiset_id in sorted(content_id_to_dandiset_paths[content_id])
+        }
+        for content_id in sorted(content_id_to_dandiset_paths)
+    }
+
     derivatives_directory = base_directory / "derivatives"
     derivatives_directory.mkdir(parents=True, exist_ok=True)
+    snapshot_file_path = derivatives_directory / "content_id_to_dandiset_paths.jsonl"
+
+    # The pipeline runs on a clone of the persistent `derivatives` branch, so the previous run's
+    # snapshot is already present here. Diff against it before overwriting, appending the deltas
+    # to `changes.jsonl` so the cache carries an explicit change history for as long as it lives.
+    # Skipped on a bootstrap run (the initial snapshot itself is the baseline), on limited
+    # (testing) runs (their truncated snapshot would only log noise), and on the first full run
+    # after a limited run (diffing against the truncated snapshot would log every entry it
+    # dropped as a spurious change) -- the `.truncated` marker carries that last state between
+    # runs on the `derivatives` branch.
+    truncated_marker_file_path = derivatives_directory / ".truncated"
+    if limit is not None:
+        truncated_marker_file_path.write_text(
+            "The snapshot was last written by a limited (testing) run and is truncated.\n"
+            "The next full run re-baselines change tracking instead of diffing against it.\n"
+        )
+    elif truncated_marker_file_path.exists():
+        print("The previous snapshot was truncated by a limited run; re-baselining change tracking.")
+        truncated_marker_file_path.unlink()
+    else:
+        previous_snapshot = _load_previous_snapshot(snapshot_file_path)
+        if previous_snapshot is not None:
+            changes_file_path = derivatives_directory / "changes.jsonl"
+            number_of_changes = _append_changes(
+                changes_file_path=changes_file_path,
+                previous_snapshot=previous_snapshot,
+                current_snapshot=current_snapshot,
+            )
+            if number_of_changes > 0:
+                print(f"Appended {number_of_changes} change record(s) to {changes_file_path}.")
+            else:
+                print("No changes since the previous snapshot.")
 
     # One JSON value per line: `{"<content_id>": {"<dandiset_id>": ["<path>", ...]}}`.
-    output_file_path = derivatives_directory / "content_id_to_dandiset_paths.jsonl"
-    with output_file_path.open(mode="w") as file_stream:
-        for content_id in sorted(content_id_to_dandiset_paths):
-            dandiset_paths = content_id_to_dandiset_paths[content_id]
-            record = {
-                content_id: {dandiset_id: sorted(dandiset_paths[dandiset_id]) for dandiset_id in sorted(dandiset_paths)}
-            }
-            file_stream.write(f"{json.dumps(record)}\n")
+    with snapshot_file_path.open(mode="w") as file_stream:
+        for content_id, dandiset_paths in current_snapshot.items():
+            file_stream.write(f"{json.dumps({content_id: dandiset_paths})}\n")
 
 
 if __name__ == "__main__":

--- a/code/update_pipeline.sh
+++ b/code/update_pipeline.sh
@@ -31,9 +31,9 @@
 #   WORKSPACE   Path to the `main` checkout that holds the code (this repository).
 #   IMAGE       Container image reference to run the processing in.
 # Optional:
-#   LIMIT        Cap on the number of asset entries update.py processes (testing knob for
-#                fast, partial runs; output has at most this many records). Empty/unset means
-#                a complete run.
+#   TESTING      Set to "true" to run update.py in testing mode: it processes only ten asset
+#                entries and reads/writes derivatives/testing.jsonl, leaving the real cache
+#                untouched. Empty/unset means a complete run.
 #   GITHUB_SHA   Recorded in the provenance message to link results to the code commit.
 #   RUNNER_TEMP  Scratch directory for the working clones (default: /tmp).
 set -euo pipefail
@@ -41,13 +41,13 @@ set -euo pipefail
 : "${REPO_URL:?REPO_URL must be set}"
 : "${WORKSPACE:?WORKSPACE must be set}"
 : "${IMAGE:?IMAGE must be set}"
-LIMIT="${LIMIT:-}"
+TESTING="${TESTING:-}"
 GITHUB_SHA="${GITHUB_SHA:-unknown}"
 
-# Only pass --limit when set, so a normal run processes the full archive.
-LIMIT_ARG=""
-if [ -n "${LIMIT}" ]; then
-  LIMIT_ARG="--limit ${LIMIT}"
+# Only pass --testing when requested, so a normal run processes the full archive.
+TESTING_ARG=""
+if [ "${TESTING}" = "true" ]; then
+  TESTING_ARG="--testing"
 fi
 
 BOT_NAME="github-actions[bot]"
@@ -104,15 +104,19 @@ datalad save -m "Pin runtime container image to ${DIGEST}" .datalad
 datalad containers-run -n pipeline \
   --output derivatives \
   -m "Update content-id-to-dandiset-paths (code @ ${GITHUB_SHA}; image ${DIGEST})" \
-  "python /code/update.py --base-directory /tmp ${LIMIT_ARG}"
+  "python /code/update.py --base-directory /tmp ${TESTING_ARG}"
 
 # Publish the full results to the `derivatives` branch.
 git -C "${DS}" push "${REPO_URL}" HEAD:derivatives
 
-# Build and force-publish the consumer-facing `dist` artifact from a fresh repo.
+# Build and force-publish the consumer-facing `dist` artifact from a fresh repo. Only the real
+# cache is published; a testing.jsonl(.gz) left by a testing run never reaches consumers. (The
+# guard only matters when a testing run precedes the first ever complete run.)
 uv run --project "${WORKSPACE}/envs" python "${WORKSPACE}/code/compress.py" --base-directory "${DS}"
 mkdir -p "${DISTDIR}/derivatives"
-cp "${DS}"/derivatives/*.jsonl.gz "${DISTDIR}/derivatives/"
+if [ -f "${DS}/derivatives/content_id_to_dandiset_paths.jsonl.gz" ]; then
+  cp "${DS}/derivatives/content_id_to_dandiset_paths.jsonl.gz" "${DISTDIR}/derivatives/"
+fi
 cp "${WORKSPACE}/dataset_description.json" "${DISTDIR}/dataset_description.json"
 git -C "${DISTDIR}" init -q -b dist
 git -C "${DISTDIR}" config user.name "${BOT_NAME}"

--- a/code/update_pipeline.sh
+++ b/code/update_pipeline.sh
@@ -8,9 +8,10 @@
 #                   into scratch. The processing is recorded there with
 #                   `datalad containers-run`, so every update carries full provenance (the
 #                   command, the output diff, and the container image digest) and history is
-#                   retained. Because the clone carries the previous run's snapshot,
-#                   update.py also diffs against it and appends the deltas to
-#                   derivatives/changes.jsonl -- an explicit, accumulating change log.
+#                   retained. Because the clone carries the previous run's cache,
+#                   update.py merges the fresh S3 state into it: new Dandiset IDs and
+#                   paths are added when first seen and existing entries are never
+#                   dropped, so the cache accumulates for as long as it lives.
 #   - `dist`        is the lightweight, force-recreated publication artifact consumed by
 #                   downstream users (see README.md).
 #

--- a/code/update_pipeline.sh
+++ b/code/update_pipeline.sh
@@ -8,7 +8,9 @@
 #                   into scratch. The processing is recorded there with
 #                   `datalad containers-run`, so every update carries full provenance (the
 #                   command, the output diff, and the container image digest) and history is
-#                   retained.
+#                   retained. Because the clone carries the previous run's snapshot,
+#                   update.py also diffs against it and appends the deltas to
+#                   derivatives/changes.jsonl -- an explicit, accumulating change log.
 #   - `dist`        is the lightweight, force-recreated publication artifact consumed by
 #                   downstream users (see README.md).
 #


### PR DESCRIPTION
## Summary
The pipeline previously regenerated the cache purely from the current state of the S3 `assets.yaml` manifests, blindly overwriting its previous output — even though the pipeline already clones the persistent `derivatives` branch before each run, so the previous state is sitting on disk. This PR makes the cache accumulative: each update reads the previous state of the cache back in and merges the fresh S3 state into it, effectively tracking changes over time for as long as the cache lives.

## Key Changes
- **New `_load_previous_cache()` function**: Reads the previous run's cache (already present in the derivatives-branch clone) back into memory
- **Accumulative merge**: The output keeps the original schema (`{"<content_id>": {"<dandiset_id>": ["<path>", ...]}}`), but new paths are appended to a content ID's list when first seen, new Dandiset IDs are added as keys, and existing entries are retained even if they later disappear upstream
- **`--limit N` replaced with a `--testing` flag**: Testing mode processes a static ten asset entries and reads/writes a designated `derivatives/testing.jsonl` instead of the real cache, so a test run can never alter the published mapping; the workflow_dispatch input is now a boolean
- **Dist publication pinned to the real cache artifact**: `testing.jsonl.gz` never reaches consumers
- **Updated documentation**: README, pipeline script header, and workflow comments reworded for the accumulative semantics ("has been seen" rather than "currently lives")

## Implementation Details
- The merge seeds the working mapping with the previous cache before folding in the fresh S3 records, so the write path is unchanged from the original code
- `_load_previous_cache()` returns an empty dictionary on a bootstrap run (no previous cache on the `derivatives` branch), making the merge loop a natural no-op
- Commit-level history of every update is additionally retained on the `derivatives` branch via the existing DataLad provenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wc1eZhJX5u8H8fMfmgqnAS