### PR TITLE
Handle inaccessible manifests gracefully in asset update pipeline

### DIFF
--- a/code/update.py
+++ b/code/update.py
@@ -7,6 +7,7 @@ import pathlib
 import boto3
 import botocore
 import botocore.config
+import botocore.exceptions
 import yaml
 
 # This cache is the first link in the DANDI cache chain: it has no upstream `sourcedata` and
@@ -42,7 +43,17 @@ def _iter_asset_manifest_keys(s3_client: "botocore.client.BaseClient"):
 
 
 def _get_info(s3_client: "botocore.client.BaseClient", key: str) -> list[tuple[str, str, str]]:
-    response = s3_client.get_object(Bucket=_BUCKET, Key=key)
+    try:
+        response = s3_client.get_object(Bucket=_BUCKET, Key=key)
+    except botocore.exceptions.ClientError as error:
+        error_code = error.response.get("Error", {}).get("Code", "")
+        # Embargoed Dandisets list their manifests in the public bucket but deny anonymous reads
+        # (AccessDenied); a manifest can also be deleted between listing and fetching (NoSuchKey).
+        # Both are expected upstream states, not pipeline failures, so skip the manifest.
+        if error_code in ("AccessDenied", "NoSuchKey", "403", "404"):
+            print(f"Skipping inaccessible manifest `{key}` ({error_code}).", flush=True)
+            return []
+        raise
     all_asset_metadata = yaml.safe_load(stream=response["Body"].read()) or []
 
     # Key layout: `dandisets/<dandiset_id>/<version>/assets.yaml`.


### PR DESCRIPTION
## Summary
Added error handling to gracefully skip inaccessible manifests during the asset manifest update process, rather than failing the entire pipeline.

## Key Changes
- Added import for `botocore.exceptions` to handle S3 client errors
- Wrapped `s3_client.get_object()` call in try-except block to catch `ClientError` exceptions
- Implemented logic to skip manifests that are inaccessible due to:
  - **AccessDenied**: Embargoed dandisets that list manifests publicly but deny anonymous reads
  - **NoSuchKey/404**: Manifests deleted between the listing and fetching steps
  - **403**: HTTP forbidden errors
- Added informative logging when a manifest is skipped, including the error code for debugging

## Implementation Details
- Returns an empty list when a manifest is inaccessible, allowing the pipeline to continue processing other manifests
- Re-raises unexpected errors to catch genuine pipeline failures
- These error conditions are treated as expected upstream states rather than pipeline failures

https://claude.ai/code/session_01WrCJJbj3qXDRAK3duwvdhX