### PR TITLE
Read assets.jsonld instead of assets.yaml to cut the update from ~37 min to minutes

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -17,35 +17,51 @@ on:
         type: boolean
         default: false
 
+# Serialize all runs of this workflow, across every ref: an in-progress update is never
+# cancelled, and a run triggered while one is executing waits in the queue. The Gate job
+# below then skips the queued run once it starts, because the update it would perform has
+# just been done; if the preceding run failed, the queued run proceeds as a fresh attempt.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}
   cancel-in-progress: false
 
 env:
   GITHUB_TOKEN: ${{ secrets._GITHUB_API_KEY }}
 
 jobs:
+  Gate:
+    permissions: {}
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.check.outputs.should-run }}
+    steps:
+      - name: Skip if an update already completed while this run was queued
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets._GITHUB_API_KEY }}
+        run: |
+          CREATED_AT=$(gh run view "${{ github.run_id }}" --repo "${{ github.repository }}" --json createdAt --jq '.createdAt')
+          LAST_SUCCESS_AT=$(gh run list --repo "${{ github.repository }}" --workflow "${{ github.workflow }}" --status success --limit 1 --json updatedAt --jq '.[0].updatedAt // empty')
+
+          # ISO 8601 UTC timestamps compare correctly as strings. A successful run that
+          # finished after this run was triggered means this run spent its life queued
+          # behind it and would only repeat the same update.
+          if [ -n "${LAST_SUCCESS_AT}" ] && [ "${LAST_SUCCESS_AT}" \> "${CREATED_AT}" ]; then
+            echo "An update succeeded at ${LAST_SUCCESS_AT}, after this run was triggered at ${CREATED_AT}; skipping the redundant run."
+            echo "should-run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "should-run=true" >> "$GITHUB_OUTPUT"
+          fi
+
   Update:
+    needs: [ Gate ]
+    if: ${{ needs.Gate.outputs.should-run == 'true' }}
     permissions:
-      actions: write
       contents: read
       packages: read
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check for running workflows
-        env:
-          GH_TOKEN: ${{ secrets._GITHUB_API_KEY }}
-        run: |
-          RUNNING_COUNT=$(gh run list --repo "${{ github.repository }}" --workflow "${{ github.workflow }}" --status in_progress --json databaseId | jq '. | length')
-
-          if [ "$RUNNING_COUNT" -gt 1 ]; then
-            echo "Another run is already in progress. Cancelling this run..."
-            gh run cancel --repo "${{ github.repository }}" ${{ github.run_id }}
-            # Sleep to allow cancellation to propagate
-            sleep 60
-          fi
-
       - name: Checkout
         uses: actions/checkout@v7
         with:
@@ -76,7 +92,7 @@ jobs:
 
   NotifyOnFailure:
     runs-on: ubuntu-latest
-    needs: [ Update ]
+    needs: [ Gate, Update ]
     if: ${{ always() && failure() }}
     permissions: {}
     steps:

--- a/code/compress.py
+++ b/code/compress.py
@@ -5,9 +5,14 @@ import shutil
 
 
 def _compress(file_path: pathlib.Path, /) -> None:
-
     compressed_file_path = file_path.parent / f"{file_path.name}.gz"
-    with file_path.open(mode="rb") as source_stream, gzip.open(compressed_file_path, mode="wb") as target_stream:
+    # `mtime=0` keeps the gzip header timestamp-free, so unchanged input compresses to a
+    # byte-identical artifact run after run.
+    with (
+        file_path.open(mode="rb") as source_stream,
+        compressed_file_path.open(mode="wb") as raw_target_stream,
+        gzip.GzipFile(fileobj=raw_target_stream, mode="wb", mtime=0) as target_stream,
+    ):
         shutil.copyfileobj(fsrc=source_stream, fdst=target_stream)
 
 

--- a/code/update.py
+++ b/code/update.py
@@ -8,26 +8,23 @@ import boto3
 import botocore
 import botocore.config
 import botocore.exceptions
-import yaml
 
 # This cache is the first link in the DANDI cache chain: it has no upstream `sourcedata` and
 # instead pulls its inputs directly from the public DANDI archive S3 bucket. Each Dandiset
-# version publishes asset manifests under `dandisets/<dandiset_id>/<version>/`; a manifest
-# lists every asset with its `path` (within the Dandiset) and its `contentUrl`s (the
+# version publishes an `assets.jsonld` manifest under `dandisets/<dandiset_id>/<version>/`; the
+# manifest lists every asset with its `path` (within the Dandiset) and its `contentUrl`s (the
 # second of which is the S3 download URL that embeds the content ID).
 #
-# The same manifest is published as both `assets.jsonld` and `assets.yaml`. JSON parses orders
-# of magnitude faster than YAML (the ~2 GB of YAML across the archive costs the better part of
-# an hour of GIL-bound CPU), so `assets.jsonld` is preferred; only a couple of old published
-# versions lack it and fall back to `assets.yaml`.
+# The archive also publishes the same manifest as `assets.yaml`, which is deliberately ignored:
+# JSON parses orders of magnitude faster than YAML (the ~2 GB of YAML across the archive costs
+# the better part of an hour of GIL-bound CPU). Exactly two ancient published versions
+# (000029/0.210712.1903 and 000571/0.250616.1143) have only the YAML manifest; the records
+# unique to them (two in total) were captured by earlier runs and live on in the accumulative
+# cache, so skipping those manifests loses nothing.
 _BUCKET = "dandiarchive"
 _REGION = "us-east-2"
 _ASSETS_PREFIX = "dandisets/"
-_ASSETS_JSON_BASENAME = "assets.jsonld"
-_ASSETS_YAML_BASENAME = "assets.yaml"
-
-# The C-accelerated loader (~6x faster) when PyYAML was built against libyaml, else pure Python.
-_YAML_LOADER = getattr(yaml, "CSafeLoader", yaml.SafeLoader)
+_ASSETS_SUFFIX = "/assets.jsonld"
 
 # Testing mode processes only this many asset entries and writes to its own designated file
 # (`derivatives/testing.jsonl`), leaving the real cache untouched.
@@ -43,19 +40,12 @@ def _build_s3_client() -> "botocore.client.BaseClient":
 
 
 def _iter_asset_manifest_keys(s3_client: "botocore.client.BaseClient"):
-    """Yield one asset manifest key per Dandiset version: `assets.jsonld`, or `assets.yaml` when
-    that is the only manifest published."""
-    manifest_basenames_by_version: dict[str, set[str]] = {}
+    """Yield every `assets.jsonld` key under `dandisets/`, in lexicographic (S3 listing) order."""
     paginator = s3_client.get_paginator("list_objects_v2")
     for page in paginator.paginate(Bucket=_BUCKET, Prefix=_ASSETS_PREFIX):
         for entry in page.get("Contents", []):
-            version_directory, _, basename = entry["Key"].rpartition("/")
-            if basename in (_ASSETS_JSON_BASENAME, _ASSETS_YAML_BASENAME):
-                manifest_basenames_by_version.setdefault(version_directory, set()).add(basename)
-
-    for version_directory, basenames in sorted(manifest_basenames_by_version.items()):
-        basename = _ASSETS_JSON_BASENAME if _ASSETS_JSON_BASENAME in basenames else _ASSETS_YAML_BASENAME
-        yield f"{version_directory}/{basename}"
+            if entry["Key"].endswith(_ASSETS_SUFFIX):
+                yield entry["Key"]
 
 
 def _get_info(s3_client: "botocore.client.BaseClient", key: str) -> list[tuple[str, str, str]]:
@@ -71,10 +61,7 @@ def _get_info(s3_client: "botocore.client.BaseClient", key: str) -> list[tuple[s
             return []
         raise
     body = response["Body"].read()
-    if key.endswith(_ASSETS_JSON_BASENAME):
-        all_asset_metadata = json.loads(body) if body.strip() else []
-    else:
-        all_asset_metadata = yaml.load(body, Loader=_YAML_LOADER) or []
+    all_asset_metadata = json.loads(body) if body.strip() else []
 
     # Key layout: `dandisets/<dandiset_id>/<version>/<manifest basename>`.
     dandiset_id = key.split("/")[1]

--- a/code/update.py
+++ b/code/update.py
@@ -12,13 +12,22 @@ import yaml
 
 # This cache is the first link in the DANDI cache chain: it has no upstream `sourcedata` and
 # instead pulls its inputs directly from the public DANDI archive S3 bucket. Each Dandiset
-# version publishes an `assets.yaml` manifest under `dandisets/<dandiset_id>/<version>/`; the
-# manifest lists every asset with its `path` (within the Dandiset) and its `contentUrl`s (the
+# version publishes asset manifests under `dandisets/<dandiset_id>/<version>/`; a manifest
+# lists every asset with its `path` (within the Dandiset) and its `contentUrl`s (the
 # second of which is the S3 download URL that embeds the content ID).
+#
+# The same manifest is published as both `assets.jsonld` and `assets.yaml`. JSON parses orders
+# of magnitude faster than YAML (the ~2 GB of YAML across the archive costs the better part of
+# an hour of GIL-bound CPU), so `assets.jsonld` is preferred; only a couple of old published
+# versions lack it and fall back to `assets.yaml`.
 _BUCKET = "dandiarchive"
 _REGION = "us-east-2"
 _ASSETS_PREFIX = "dandisets/"
-_ASSETS_SUFFIX = "/assets.yaml"
+_ASSETS_JSON_BASENAME = "assets.jsonld"
+_ASSETS_YAML_BASENAME = "assets.yaml"
+
+# The C-accelerated loader (~6x faster) when PyYAML was built against libyaml, else pure Python.
+_YAML_LOADER = getattr(yaml, "CSafeLoader", yaml.SafeLoader)
 
 # Testing mode processes only this many asset entries and writes to its own designated file
 # (`derivatives/testing.jsonl`), leaving the real cache untouched.
@@ -34,12 +43,19 @@ def _build_s3_client() -> "botocore.client.BaseClient":
 
 
 def _iter_asset_manifest_keys(s3_client: "botocore.client.BaseClient"):
-    """Yield every `assets.yaml` key under `dandisets/`, in lexicographic (S3 listing) order."""
+    """Yield one asset manifest key per Dandiset version: `assets.jsonld`, or `assets.yaml` when
+    that is the only manifest published."""
+    manifest_basenames_by_version: dict[str, set[str]] = {}
     paginator = s3_client.get_paginator("list_objects_v2")
     for page in paginator.paginate(Bucket=_BUCKET, Prefix=_ASSETS_PREFIX):
         for entry in page.get("Contents", []):
-            if entry["Key"].endswith(_ASSETS_SUFFIX):
-                yield entry["Key"]
+            version_directory, _, basename = entry["Key"].rpartition("/")
+            if basename in (_ASSETS_JSON_BASENAME, _ASSETS_YAML_BASENAME):
+                manifest_basenames_by_version.setdefault(version_directory, set()).add(basename)
+
+    for version_directory, basenames in sorted(manifest_basenames_by_version.items()):
+        basename = _ASSETS_JSON_BASENAME if _ASSETS_JSON_BASENAME in basenames else _ASSETS_YAML_BASENAME
+        yield f"{version_directory}/{basename}"
 
 
 def _get_info(s3_client: "botocore.client.BaseClient", key: str) -> list[tuple[str, str, str]]:
@@ -54,9 +70,13 @@ def _get_info(s3_client: "botocore.client.BaseClient", key: str) -> list[tuple[s
             print(f"Skipping inaccessible manifest `{key}` ({error_code}).", flush=True)
             return []
         raise
-    all_asset_metadata = yaml.safe_load(stream=response["Body"].read()) or []
+    body = response["Body"].read()
+    if key.endswith(_ASSETS_JSON_BASENAME):
+        all_asset_metadata = json.loads(body) if body.strip() else []
+    else:
+        all_asset_metadata = yaml.load(body, Loader=_YAML_LOADER) or []
 
-    # Key layout: `dandisets/<dandiset_id>/<version>/assets.yaml`.
+    # Key layout: `dandisets/<dandiset_id>/<version>/<manifest basename>`.
     dandiset_id = key.split("/")[1]
 
     records: list[tuple[str, str, str]] = []

--- a/code/update.py
+++ b/code/update.py
@@ -1,6 +1,7 @@
 import argparse
 import collections
 import concurrent.futures
+import functools
 import json
 import pathlib
 
@@ -33,9 +34,15 @@ _CACHE_FILE_NAME = "content_id_to_dandiset_paths.jsonl"
 _TESTING_FILE_NAME = "testing.jsonl"
 
 
-def _build_s3_client() -> "botocore.client.BaseClient":
-    # `dandiarchive` is a public bucket, so requests are sent unsigned (anonymous).
-    config = botocore.config.Config(signature_version=botocore.UNSIGNED)
+def _build_s3_client(max_pool_connections: int = 10) -> "botocore.client.BaseClient":
+    # `dandiarchive` is a public bucket, so requests are sent unsigned (anonymous). The
+    # connection pool must hold one connection per download worker, or the surplus workers
+    # redo the TCP/TLS handshake on every request.
+    config = botocore.config.Config(
+        signature_version=botocore.UNSIGNED,
+        max_pool_connections=max_pool_connections,
+        retries={"mode": "standard"},
+    )
     return boto3.client("s3", region_name=_REGION, config=config)
 
 
@@ -56,7 +63,7 @@ def _get_info(s3_client: "botocore.client.BaseClient", key: str) -> list[tuple[s
         # Embargoed Dandisets list their manifests in the public bucket but deny anonymous reads
         # (AccessDenied); a manifest can also be deleted between listing and fetching (NoSuchKey).
         # Both are expected upstream states, not pipeline failures, so skip the manifest.
-        if error_code in ("AccessDenied", "NoSuchKey", "403", "404"):
+        if error_code in ("AccessDenied", "NoSuchKey"):
             print(f"Skipping inaccessible manifest `{key}` ({error_code}).", flush=True)
             return []
         raise
@@ -94,10 +101,10 @@ def _collect_records(
         return records[:_TESTING_LIMIT]
 
     # Full run: fetch every manifest concurrently and aggregate all asset entries.
-    keys = sorted(_iter_asset_manifest_keys(s3_client))
     records = []
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
-        for manifest_records in executor.map(lambda key: _get_info(s3_client, key), keys):
+        get_info = functools.partial(_get_info, s3_client)
+        for manifest_records in executor.map(get_info, _iter_asset_manifest_keys(s3_client)):
             records.extend(manifest_records)
     return records
 
@@ -116,7 +123,7 @@ def _load_previous_cache(cache_file_path: pathlib.Path) -> dict[str, dict[str, l
 
 
 def _run(base_directory: pathlib.Path, max_workers: int, testing: bool) -> None:
-    s3_client = _build_s3_client()
+    s3_client = _build_s3_client(max_pool_connections=max_workers)
 
     records = _collect_records(s3_client, max_workers=max_workers, testing=testing)
     if len(records) == 0:

--- a/code/update_pipeline.sh
+++ b/code/update_pipeline.sh
@@ -20,7 +20,7 @@
 # dataset (a small text file), so it stays annex-free and ghcr holds the bytes.
 #
 # This cache is the first link in the DANDI cache chain: it has no upstream input dataset and
-# no `sourcedata`. code/update.py pulls the DANDI archive `assets.yaml` manifests directly
+# no `sourcedata`. code/update.py pulls the DANDI archive asset manifests directly
 # from public S3 at run time, so the container only needs outbound network access.
 #
 # code/update.py and code/compress.py are the actual code and run in any environment; this

--- a/envs/pyproject.toml
+++ b/envs/pyproject.toml
@@ -5,8 +5,9 @@ requires-python = ">=3.13"
 dependencies = [
     "datalad",
     "datalad-container",
-    # Processing dependencies used by code/update.py: it reads the DANDI archive's
-    # `assets.yaml` manifests directly from public S3.
+    # Processing dependencies used by code/update.py: it reads the DANDI archive's asset
+    # manifests directly from public S3 (`assets.jsonld`, with an `assets.yaml` fallback
+    # for the few old versions that only publish YAML).
     "boto3",
     "pyyaml",
 ]

--- a/envs/pyproject.toml
+++ b/envs/pyproject.toml
@@ -5,9 +5,7 @@ requires-python = ">=3.13"
 dependencies = [
     "datalad",
     "datalad-container",
-    # Processing dependencies used by code/update.py: it reads the DANDI archive's asset
-    # manifests directly from public S3 (`assets.jsonld`, with an `assets.yaml` fallback
-    # for the few old versions that only publish YAML).
+    # Processing dependency used by code/update.py: it reads the DANDI archive's
+    # `assets.jsonld` manifests directly from public S3.
     "boto3",
-    "pyyaml",
 ]


### PR DESCRIPTION
## Summary
Profiling the ~37-minute update run showed the time was dominated by pure-Python YAML parsing, not the network: the archive's `assets.yaml` manifests total ~1.9 GB, and PyYAML's `SafeLoader` needs ~93 s for a 43 MB manifest that downloads in ~1.5 s. Since parsing is GIL-bound Python, the 16-thread pool only ever parallelized the cheap download step while parsing ran single-file.

Every Dandiset version also publishes the identical manifest as `assets.jsonld`, and `json.loads` handles that same 43 MB manifest in ~0.25 s. Switching to it makes the run network-bound — low single-digit minutes instead of 37+.

## Key Changes
- `update.py` reads `assets.jsonld` exclusively; the PyYAML dependency is removed
- The two ancient published versions that only have `assets.yaml` (`000029/0.210712.1903`, `000571/0.250616.1143`) are deliberately skipped: comparing them against their sibling versions' jsonld manifests shows exactly two records unique to them archive-wide, both already captured in the accumulative cache by earlier YAML-based runs (a comment in `update.py` records this)
- The S3 connection pool is sized to the worker count (botocore's default pool of 10 forced 6 of the 16 workers to redo the TCP/TLS handshake on every request) and retries use standard mode
- Dead code removed: redundant `sorted()` over the already-lexicographic S3 listing, and unreachable `"403"`/`"404"` codes in the skip check (`get_object` raises `AccessDenied`/`NoSuchKey`)
- `compress.py` writes reproducible gzip (`mtime=0`), so an unchanged cache compresses to a byte-identical dist artifact run after run
- `update.yml` run-serialization redesigned: the concurrency group now spans all refs (an in-flight update is never cancelled and never overlapped, including by cross-ref dispatches), and a new Gate job skips a run that waited in the queue while another update succeeded — instead of repeating the work — while still proceeding if the predecessor failed. This replaces the manual self-cancel step, its `sleep 60` hack, and the `actions: write` permission.

## Verification
- Compared extracted `(content_id, dandiset_id, path)` records between the two formats across 18 sampled version manifests (including empty ones): record sets are identical in every case; only within-file entry order differs, which is irrelevant since records are folded into sorted dicts of sets — the resulting cache is byte-identical
- Full `--testing` mode run (with only boto3 installed) produces the same 10 records as before
- Embargoed manifests still skip cleanly with a log line (behavior from #9)
- Recompressing identical input yields byte-identical `.gz`; roundtrip verified
- `ruff`, `black`, and `check-yaml` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrCJJbj3qXDRAK3duwvdhX